### PR TITLE
Add flysystem dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
             "email": "syed+gh@lukonet.com"
         }
     ],
+    "require": {
+        "league/flysystem": "~1.0"
+    },
     "autoload": {
       "files": [
         "helpers.php"


### PR DESCRIPTION
Lumen itself doesn't depend on league/flysystem, but it is required for the `vendor:publish` command.
