### PR TITLE
Helper result modified

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -80,7 +80,7 @@ if (!function_exists('elixir')) {
         }
 
         if (isset($manifest[$file])) {
-            return '/'.$buildPath.'/'.$manifest[$file];
+            return url($buildPath.'/'.$manifest[$file]);
         }
 
         throw new InvalidArgumentException("File {$file} not defined in asset manifest.");


### PR DESCRIPTION
URL starting with "/" could be incorrect if the website is not in domain root.
