### PR TITLE
Adding bcrypt() to helpers

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -109,7 +109,7 @@ if (!function_exists('bcrypt'))
 	 * @param array  $options
 	 *
 	 * @return string
-	**/
+	 */
 	function bcrypt($value, $options = array())
 	{
 		return app('hash')->make($value, $options);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -99,3 +99,19 @@ if (!function_exists('elixir')) {
         throw new InvalidArgumentException("File {$file} not defined in asset manifest.");
     }
 }
+
+if (!function_exists('bcrypt'))
+{
+	/**
+	 * Hash the given value
+	 *
+	 * @param string $value
+	 * @param array  $options
+	 *
+	 * @return string
+	**/
+	function bcrypt($value, $options = array())
+	{
+		return app('hash')->make($value, $options);
+	}
+}


### PR DESCRIPTION
`bcrypt()` is a function used in Laravel for hashing purposes, typically for passwords, and is not included in Lumen by default and is simply an alias for `app('hash')->make()`. I ran into this problem when integrating [Laratrust](https://github.com/santigarcor/laratrust) into my Lumen project.